### PR TITLE
Bump to v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# [1.4.0](https://github.com/CESARBR/knot-cloud/compare/v1.3.0...v1.4.0)
+
+### Features
+
+- Add CLI commands to operate on the cloud:
+  - Create thing
+  - Create gateway
+  - List devices
+  - Set data
+  - Get data
+  - Publish data
+  - Listen data
+  - Update schema
+  - Create session token
+  - Delete device
+
+### Bug Fixes
+
+- Update packages to fix vulnerability issues
+- Fix traefik version in v1.7
+
 # [1.3.0 / KNOT-v02.00](https://github.com/CESARBR/knot-cloud/compare/v1.2.0...v1.3.0)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cesarbr/knot-cloud",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cesarbr/knot-cloud",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "KNoT Cloud CLI",
   "contributors": [
     "Thiago Cardoso <thiago.figuerdo@cesar.org.br>",

--- a/stacks/dev/stage-1.yml
+++ b/stacks/dev/stage-1.yml
@@ -68,7 +68,7 @@ services:
           memory: 300M
   # Proxy
   traefik:
-    image: traefik
+    image: traefik:v1.7
     command: >
       traefik
         --docker

--- a/stacks/prod/all-in-one/stage-1.yml
+++ b/stacks/prod/all-in-one/stage-1.yml
@@ -37,7 +37,7 @@ services:
         - traefik.frontend.rule=HostRegexp:ws,ws.{domain:[a-zA-Z0-9.]+}
         - traefik.port=80
   storage:
-    image: cesarbr/knot-cloud-storage:v1.0.2
+    image: cesarbr/knot-cloud-storage:v1.0.3
     env_file: '../env.d/knot-cloud-storage.env'
     deploy:
       replicas: 1

--- a/stacks/prod/all-in-one/stage-1.yml
+++ b/stacks/prod/all-in-one/stage-1.yml
@@ -62,7 +62,7 @@ services:
           memory: 300M
   # Proxy
   traefik:
-    image: traefik
+    image: traefik:v1.7
     command: >
       traefik
         --docker

--- a/stacks/prod/all-in-one/stage-2.yml
+++ b/stacks/prod/all-in-one/stage-2.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   authenticator:
-    image: cesarbr/knot-cloud-authenticator:v1.4.0
+    image: cesarbr/knot-cloud-authenticator:v1.4.1
     env_file: '../env.d/knot-cloud-authenticator.env'
     deploy:
       replicas: 1
@@ -10,7 +10,7 @@ services:
         - traefik.frontend.rule=HostRegexp:auth,auth.{domain:[a-zA-Z0-9.]+}
         - traefik.port=80
   ui:
-    image: cesarbr/knot-cloud-ui:v1.1.0
+    image: cesarbr/knot-cloud-ui:v1.1.1
     env_file: '../env.d/knot-cloud-ui.env'
     deploy:
       replicas: 1

--- a/stacks/prod/multinode/stage-1.yml
+++ b/stacks/prod/multinode/stage-1.yml
@@ -76,7 +76,7 @@ services:
           memory: 300M
   # Proxy
   traefik:
-    image: traefik
+    image: traefik:v1.7
     command: >
       traefik
         --docker

--- a/stacks/prod/multinode/stage-1.yml
+++ b/stacks/prod/multinode/stage-1.yml
@@ -49,7 +49,7 @@ services:
         - traefik.frontend.rule=HostRegexp:ws,ws.{domain:[a-zA-Z0-9.]+}
         - traefik.port=80
   storage:
-    image: cesarbr/knot-cloud-storage:v1.0.2
+    image: cesarbr/knot-cloud-storage:v1.0.3
     env_file: '../env.d/knot-cloud-storage.env'
     deploy:
       replicas: 1

--- a/stacks/prod/multinode/stage-2.yml
+++ b/stacks/prod/multinode/stage-2.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   authenticator:
-    image: cesarbr/knot-cloud-authenticator:v1.4.0
+    image: cesarbr/knot-cloud-authenticator:v1.4.1
     env_file: '../env.d/knot-cloud-authenticator.env'
     deploy:
       replicas: 1
@@ -12,7 +12,7 @@ services:
         - traefik.frontend.rule=HostRegexp:auth,auth.{domain:[a-zA-Z0-9.]+}
         - traefik.port=80
   ui:
-    image: cesarbr/knot-cloud-ui:v1.1.0
+    image: cesarbr/knot-cloud-ui:v1.1.1
     env_file: '../env.d/knot-cloud-ui.env'
     deploy:
       replicas: 1


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR bumps the current version to v1.4.0. The main changes are:

- Update the stack `yaml` files with the newer version of the KNoT services.
- Fix the `traeffik` version to be v1.7 since the latest (v2.x) isn't compatible with the current configuration.

Does this close any currently open issues?
------------------------------------------
Nops.

Any relevant logs, error output, etc?
-------------------------------------
Nops.

Any other comments?
-------------------
Nops.