### PR TITLE
CLI 'init' command fix

### DIFF
--- a/src/cmds/stack/setup.js
+++ b/src/cmds/stack/setup.js
@@ -49,12 +49,14 @@ const cpDevDir = (basePath) => {
 };
 
 const initStack = (args) => {
+  const initPath = args.path || '';
+
   if (fs.existsSync(KNOT_ERR_PATH)) {
     fs.unlinkSync(KNOT_ERR_PATH);
   }
   REPOSITORIES.forEach((repo) => {
     const repoName = repo.split('/')[1];
-    const repoPath = `${args.path}/${repoName}`;
+    const repoPath = path.join(initPath, repoName);
     console.log(`Cloning: ${repoName}`);
     gitClone(
       `http://github.com/${repo}`,
@@ -69,7 +71,7 @@ const initStack = (args) => {
       },
     );
   });
-  cpDevDir(args.path);
+  cpDevDir(initPath);
 };
 
 yargs // eslint-disable-line import/no-extraneous-dependencies

--- a/src/cmds/stack/setup.js
+++ b/src/cmds/stack/setup.js
@@ -40,7 +40,7 @@ const cpDevDir = (basePath) => {
       fs.removeSync(stackDir);
     }
     fs.ensureDirSync(stackDir);
-    fs.copySync(`${__dirname}/stacks/dev`, stackDir);
+    fs.copySync(`${__dirname}/../../stacks/dev`, stackDir);
     console.log('Created development stack files');
   } catch (err) {
     const msg = '[Error]:\n\tAn error occurred while copying the development stack files.';


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix command init for knot-cloud cli:
- Fix path in copy stacks folder
- Fix path used to clone the repositories

Does this close any currently open issues?
------------------------------------------
fix #20

Any relevant logs, error output, etc?
-------------------------------------

Any other comments?
-------------------

Where has this been tested?
---------------------------
Ubuntu 18.04.3
NPM v6.13.6
NodeJS v12.13.1
