### PR TITLE
fix(dev-stack): storage listen on wrong port

### DIFF
--- a/stacks/dev/stage-1.yml
+++ b/stacks/dev/stage-1.yml
@@ -50,7 +50,7 @@ services:
       labels:
         - traefik.enable=true
         - traefik.frontend.rule=HostRegexp:data,data.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=80
+        - traefik.port=8080
   # Storage
   mongo:
     image: mongo


### PR DESCRIPTION
Fix traefik port for storage service in the development stack.

What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch fixes the traefik port for storage service in development stack

Does this close any currently open issues?
------------------------------------------

Any relevant logs, error output, etc?
-------------------------------------

Any other comments?
-------------------

Where has this been tested?
---------------------------
**Operating System/Platform:** Ubuntu 18.04.3
**NPM Version:** 6.13.6
**NodeJS Version:** 12.13.1

@joaoaneto 