### PR TITLE
Add Storage (golang version) to core stack

### DIFF
--- a/src/cmds/stack/setup.js
+++ b/src/cmds/stack/setup.js
@@ -14,6 +14,7 @@ const KNOT_CLOUD_REPOSITORIES = [
 
 const KNOT_CLOUD_CORE_REPOSITORIES = [
   'CESARBR/knot-babeltower',
+  'CESARBR/knot-cloud-storage:migration_golang',
 ];
 
 const KNOT_ERR_FILE = 'knot.err';
@@ -53,13 +54,15 @@ const cpDevDir = (basePath, version) => {
 };
 
 const cloneRepositories = (initPath, repositories) => {
-  repositories.forEach((repo) => {
+  repositories.forEach((fullRepo) => {
+    const [repo, branch] = fullRepo.split(':');
     const repoName = repo.split('/')[1];
     const repoPath = path.join(initPath, repoName);
     console.log(`Cloning: ${repoName}`);
     gitClone(
       `http://github.com/${repo}`,
       repoPath,
+      { checkout: branch },
       (err) => {
         if (err) {
           const msg = `[Error]:\n\tAn error occured while cloning repository ${repoName}`;
@@ -84,6 +87,9 @@ const initStack = (args) => {
     cloneRepositories(initPath, KNOT_CLOUD_REPOSITORIES);
   } else if (version === 'core') {
     cloneRepositories(initPath, KNOT_CLOUD_CORE_REPOSITORIES);
+  } else {
+    console.log('Invalid cloud version selected. Please type \'cloud\' or \'core\'');
+    return;
   }
 
   cpDevDir(initPath, version);

--- a/stacks/core/dev/env.d/knot-cloud-storage.env
+++ b/stacks/core/dev/env.d/knot-cloud-storage.env
@@ -1,0 +1,2 @@
+DB_HOSTNAME=mongo
+DB_PORT=27017

--- a/stacks/core/dev/stage-1.yml
+++ b/stacks/core/dev/stage-1.yml
@@ -41,6 +41,20 @@ services:
         - traefik.port=8183
 
   # KNoT Fog Core
+  storage:
+    image: cesarbr/knot-cloud-storage-go:dev
+    env_file: './env.d/knot-cloud-storage.env'
+    volumes:
+      - ../knot-cloud-storage:/usr/src/app
+    depends_on:
+      - mongo
+    deploy:
+      replicas: 1
+      labels:
+        - traefik.enable=true
+        - traefik.frontend.rule=HostRegexp:storage,storage.{domain:[a-zA-Z0-9.]+}
+        - traefik.port=8181
+
   babeltower:
     image: cesarbr/knot-babeltower:dev
     env_file: './env.d/knot-babeltower.env'
@@ -90,6 +104,15 @@ services:
     volumes:
       - mainflux-authn-db-volume:/var/lib/postgresql/data
 
+  mongo:
+    image: mongo
+    volumes:
+      - knot-cloud-db-volume:/var/lib/mongo/data
+    deploy:
+      resources:
+        limits:
+          memory: 300M
+
   rabbitmq:
     image: rabbitmq:management
     env_file: './env.d/rabbitmq.env'
@@ -128,3 +151,4 @@ volumes:
   mainflux-things-db-volume:
   mainflux-users-db-volume:
   mainflux-authn-db-volume:
+  knot-cloud-db-volume:


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch adds the storage service to the new core stack

Where has this been tested?
---------------------------
**Operating System/Platform:** Ubuntu 18.04.4
**Go Version:** go1.13.8
