### PR TITLE
Add argument to select stack environment

### DIFF
--- a/src/cmds/stack/setup.js
+++ b/src/cmds/stack/setup.js
@@ -37,7 +37,7 @@ function handleError(err, msg, logFileMessage) {
   fs.writeFileSync(KNOT_ERR_PATH, `${err.stack}\n`, { flag: 'a', encoding: 'utf-8' });
 }
 
-const cpDevDir = (basePath, version) => {
+const cpEnvDir = (basePath, version, env) => {
   const stackDir = path.join(basePath, 'stack');
 
   try {
@@ -45,10 +45,10 @@ const cpDevDir = (basePath, version) => {
       fs.removeSync(stackDir);
     }
     fs.ensureDirSync(stackDir);
-    fs.copySync(`${__dirname}/../../stacks/${version}/dev`, stackDir);
-    console.log('Created development stack files');
+    fs.copySync(`${__dirname}/../../stacks/${version}/${env}`, stackDir);
+    console.log(`Created ${env} stack files`);
   } catch (err) {
-    const msg = '[Error]:\n\tAn error occurred while copying the development stack files.';
+    const msg = `[Error]:\n\tAn error occurred while copying the ${env} stack files.`;
     handleError(err, msg, logFileMessageCopyStack);
   }
 };
@@ -78,6 +78,7 @@ const cloneRepositories = (initPath, repositories) => {
 const initStack = (args) => {
   const initPath = args.path || '';
   const version = args.cloudVersion || 'cloud';
+  const env = args.env || 'dev';
 
   if (fs.existsSync(KNOT_ERR_PATH)) {
     fs.unlinkSync(KNOT_ERR_PATH);
@@ -92,13 +93,17 @@ const initStack = (args) => {
     return;
   }
 
-  cpDevDir(initPath, version);
+  if (env === 'dev' || env === 'prod') {
+    cpEnvDir(initPath, version, env);
+  } else {
+    console.log('Invalid stack environment selected. Please type \'dev\' or \'prod\'');
+  }
 };
 
 yargs // eslint-disable-line import/no-extraneous-dependencies
   .command({
-    command: 'init [cloudVersion] [path]',
-    desc: 'Initialize [cloudVersion] stack at [path]',
+    command: 'init [cloudVersion] [env] [path]',
+    desc: 'Initialize [cloudVersion] [env] stack at [path]',
     handler: (args) => {
       initStack(args);
     },


### PR DESCRIPTION
<!--
This Pull Request Template is a modified version from Vuejs's:
https://raw.githubusercontent.com/vuejs/vue/dev/.github/PULL_REQUEST_TEMPLATE.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Describe what this PR introduces:** 
(if necessary, link currently open issues with [special keywords](https://help.github.com/en/articles/closing-issues-using-keywords))

- Add `env` argument to the CLI so that the user may specify if they want to replicate the `dev` or `prod` stack files (defaults to `dev`).

**What kind of change does this PR introduce?** (check at least one)

- [x] Bug fix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe: 

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [X] New/updated tests are included

**Testing environment:**

- Operating System/Platform: N/A :stuck_out_tongue: 
- Go version: N/A :stuck_out_tongue: 
- Node version: v13.11.0
- NPM version: 6.14.3
- KNoT Cloud CLI version: 1.4.0 

If you have relevant logs, error output and etc, please attach them.

**Other information:**

Whilst adding the KNoT Cloud CLI version above, I questioned if there a need to bump this version (if the new feature is accepted) :eyes: 