### PR TITLE
chore(core): Update traefik version to v2.2

### DIFF
--- a/stacks/core/README.md
+++ b/stacks/core/README.md
@@ -2,15 +2,12 @@
 
 ### Configure DNS
 
-This stack uses [Traefik](https://traefik.io) as a reverse proxy for the services and requires that you configure your DNS server to point, at least, the **things**, **users** and **bt** subdomains to the machine where the stack is being deployed, so that it can route the requests to the appropriated service. It is possible to configure it to route by path or port, but instructions for that won't be provided here for brevity.
+This stack uses [Traefik](https://traefik.io) as a reverse proxy for the services and requires that you configure your DNS server to point, at least, the **api** and **storage** subdomains to the machine where the stack is being deployed, so that it can route the requests to the appropriated service. It is possible to configure it to route by path or port, but instructions for that won't be provided here for brevity.
 
 If you don't have a domain or can't configure the main DNS server, you can configure a test domain in your machine before proceeding. Either setup a local DNS server, e.g. [bind9](https://wiki.debian.org/Bind9), or alternatively update your hosts file to include the following addresses:
 
 ```
-127.0.0.1   things
-127.0.0.1   users
-127.0.0.1   authn
-127.0.0.1   bt
+127.0.0.1   api
 127.0.0.1   storage
 ```
 

--- a/stacks/core/dev/stage-1.yml
+++ b/stacks/core/dev/stage-1.yml
@@ -12,8 +12,9 @@ services:
       replicas: 1
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:users,users.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8180
+        - traefik.http.services.users.loadbalancer.server.port=8180
+        - traefik.http.routers.users.rule=HostRegexp(`{subdomain:users}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.users.entrypoints=http
 
   things:
     image: mainflux/things:0.10.0
@@ -25,8 +26,9 @@ services:
       replicas: 1
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:things,things.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8182
+        - traefik.http.services.things.loadbalancer.server.port=8182
+        - traefik.http.routers.things.rule=HostRegexp(`{subdomain:things}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.things.entrypoints=http
 
   authn:
     image: mainflux/authn:0.10.0
@@ -37,8 +39,9 @@ services:
       replicas: 1
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:authn,authn.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8183
+        - traefik.http.services.authn.loadbalancer.server.port=8183
+        - traefik.http.routers.authn.rule=HostRegexp(`{subdomain:authn}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.authn.entrypoints=http
 
   # KNoT Fog Core
   storage:
@@ -52,8 +55,9 @@ services:
       replicas: 1
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:storage,storage.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8181
+        - traefik.http.services.storage.loadbalancer.server.port=8181
+        - traefik.http.routers.storage.rule=HostRegexp(`{subdomain:storage}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.storage.entrypoints=http
 
   babeltower:
     image: cesarbr/knot-babeltower:dev
@@ -68,8 +72,9 @@ services:
       replicas: 1
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:bt,bt.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8080
+        - traefik.http.services.babeltower.loadbalancer.server.port=8080
+        - traefik.http.routers.babeltower.rule=HostRegexp(`{subdomain:api}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.babeltower.entrypoints=http
 
   # External dependencies: database, tracing, message broker, load balancer.
   things-redis:
@@ -118,9 +123,16 @@ services:
     env_file: './env.d/rabbitmq.env'
     deploy:
       replicas: 1
-    ports:
-      - 5672:5672
-      - 15672:15672
+      labels:
+        - traefik.enable=true
+        # Management dashboard configuration
+        - traefik.http.services.rabbitmq-admin.loadbalancer.server.port=15672
+        - traefik.http.routers.rabbitmq-admin.rule=HostRegexp(`{subdomain:admin}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.rabbitmq-admin.entrypoints=management
+        # AMQP configuration
+        - traefik.tcp.services.rabbitmq.loadbalancer.server.port=5672
+        - traefik.tcp.routers.rabbitmq.rule=HostSNI(`*`)
+        - traefik.tcp.routers.rabbitmq.entrypoints=broker
 
   jaeger:
     image: jaegertracing/all-in-one:1.13
@@ -129,19 +141,20 @@ services:
       replicas: 1
 
   traefik:
-    image: traefik:v1.7
+    image: traefik:v2.2
     command: >
       traefik
-        --docker
-        --docker.watch
-        --docker.swarmMode
-        --docker.exposedByDefault=false
-        --entryPoints='Name:http Address::80 Redirect.EntryPoint:https'
-        --entryPoints='Name:https Address::443 TLS'
-        --defaultEntryPoints=http,https
+        --providers.docker
+        --providers.docker.watch
+        --providers.docker.swarmMode
+        --providers.docker.exposedByDefault=false
+        --entrypoints.http.address=:80
+        --entrypoints.management.address=:15672
+        --entrypoints.broker.address=:5672
     ports:
       - '80:80'
-      - '443:443'
+      - '5672:5672'
+      - '15672:15672'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     deploy:

--- a/stacks/core/prod/all-in-one/stage-1.yml
+++ b/stacks/core/prod/all-in-one/stage-1.yml
@@ -12,8 +12,9 @@ services:
       replicas: 1
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:users,users.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8180
+        - traefik.http.services.users.loadbalancer.server.port=8180
+        - traefik.http.routers.users.rule=HostRegexp(`{subdomain:users}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.users.entrypoints=http
 
   things:
     image: mainflux/things:0.10.0
@@ -25,8 +26,9 @@ services:
       replicas: 1
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:things,things.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8182
+        - traefik.http.services.things.loadbalancer.server.port=8182
+        - traefik.http.routers.things.rule=HostRegexp(`{subdomain:things}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.things.entrypoints=http
 
   authn:
     image: mainflux/authn:0.10.0
@@ -37,8 +39,9 @@ services:
       replicas: 1
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:authn,authn.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8183
+        - traefik.http.services.authn.loadbalancer.server.port=8183
+        - traefik.http.routers.authn.rule=HostRegexp(`{subdomain:authn}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.authn.entrypoints=http
 
   # KNoT Fog Core
   # Use the Go version of cesarbr/knot-cloud-storage
@@ -51,8 +54,10 @@ services:
       replicas: 1
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:storage,storage.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8181
+        - traefik.http.services.storage.loadbalancer.server.port=8181
+        - traefik.http.routers.storage.rule=HostRegexp(`{subdomain:storage}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.storage.entrypoints=http
+
   babeltower:
     image: cesarbr/knot-babeltower
     env_file: '../env.d/knot-babeltower.env'
@@ -64,8 +69,9 @@ services:
       replicas: 1
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:bt,bt.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=80
+        - traefik.http.services.babeltower.loadbalancer.server.port=8080
+        - traefik.http.routers.babeltower.rule=HostRegexp(`{subdomain:api}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.babeltower.entrypoints=http
 
   # External dependencies: database, tracing, message broker, load balancer.
   things-redis:
@@ -114,9 +120,17 @@ services:
     env_file: '../env.d/rabbitmq.env'
     deploy:
       replicas: 1
-    ports:
-      - 5672:5672
-      - 15672:15672
+      labels:
+        - traefik.enable=true
+        # Management dashboard configuration
+        - traefik.http.services.rabbitmq-admin.loadbalancer.server.port=15672
+        - traefik.http.routers.rabbitmq-admin.rule=HostRegexp(`{subdomain:admin}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.rabbitmq-admin.entrypoints=management
+        # AMQP configuration
+        - traefik.tcp.services.rabbitmq.loadbalancer.server.port=5672
+        - traefik.tcp.routers.rabbitmq.rule=HostSNI(`*`)
+        - traefik.tcp.routers.rabbitmq.entrypoints=broker
+
 
   jaeger:
     image: jaegertracing/all-in-one:1.13
@@ -125,19 +139,20 @@ services:
       replicas: 1
 
   traefik:
-    image: traefik:v1.7
+    image: traefik:v2.2
     command: >
       traefik
-        --docker
-        --docker.watch
-        --docker.swarmMode
-        --docker.exposedByDefault=false
-        --entryPoints='Name:http Address::80 Redirect.EntryPoint:https'
-        --entryPoints='Name:https Address::443 TLS'
-        --defaultEntryPoints=http,https
+        --providers.docker
+        --providers.docker.watch
+        --providers.docker.swarmMode
+        --providers.docker.exposedByDefault=false
+        --entrypoints.http.address=:80
+        --entrypoints.management.address=:15672
+        --entrypoints.broker.address=:5672
     ports:
       - '80:80'
-      - '443:443'
+      - '5672:5672'
+      - '15672:15672'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     deploy:

--- a/stacks/core/prod/multinode/stage-1.yml
+++ b/stacks/core/prod/multinode/stage-1.yml
@@ -13,8 +13,9 @@ services:
         constraints: [node.role == worker]
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:users,users.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8180
+        - traefik.http.services.users.loadbalancer.server.port=8180
+        - traefik.http.routers.users.rule=HostRegexp(`{subdomain:users}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.users.entrypoints=http
 
   things:
     image: mainflux/things:0.10.0
@@ -28,8 +29,9 @@ services:
         constraints: [node.role == worker]
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:things,things.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8182
+        - traefik.http.services.things.loadbalancer.server.port=8182
+        - traefik.http.routers.things.rule=HostRegexp(`{subdomain:things}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.things.entrypoints=http
 
   authn:
     image: mainflux/authn:0.10.0
@@ -42,8 +44,9 @@ services:
         constraints: [node.role == worker]
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:authn,authn.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8183
+        - traefik.http.services.authn.loadbalancer.server.port=8183
+        - traefik.http.routers.authn.rule=HostRegexp(`{subdomain:authn}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.authn.entrypoints=http
 
   # KNoT Fog Core
   # Use the Go version of cesarbr/knot-cloud-storage
@@ -58,8 +61,10 @@ services:
         constraints: [node.role == worker]
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:storage,storage.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=8181
+        - traefik.http.services.storage.loadbalancer.server.port=8181
+        - traefik.http.routers.storage.rule=HostRegexp(`{subdomain:storage}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.storage.entrypoints=http
+
   babeltower:
     image: cesarbr/knot-babeltower
     env_file: '../env.d/knot-babeltower.env'
@@ -73,8 +78,9 @@ services:
         constraints: [node.role == worker]
       labels:
         - traefik.enable=true
-        - traefik.frontend.rule=HostRegexp:bt,bt.{domain:[a-zA-Z0-9.]+}
-        - traefik.port=80
+        - traefik.http.services.babeltower.loadbalancer.server.port=8080
+        - traefik.http.routers.babeltower.rule=HostRegexp(`{subdomain:api}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.babeltower.entrypoints=http
 
   # External dependencies: database, tracing, message broker, load balancer.
   things-redis:
@@ -125,9 +131,16 @@ services:
       replicas: 1
       placement:
         constraints: [node.role == worker]
-    ports:
-      - 5672:5672
-      - 15672:15672
+      labels:
+        - traefik.enable=true
+        # Management dashboard configuration
+        - traefik.http.services.rabbitmq-admin.loadbalancer.server.port=15672
+        - traefik.http.routers.rabbitmq-admin.rule=HostRegexp(`{subdomain:admin}.{domain:[a-zA-Z0-9.]+}`)
+        - traefik.http.routers.rabbitmq-admin.entrypoints=management
+        # AMQP configuration
+        - traefik.tcp.services.rabbitmq.loadbalancer.server.port=5672
+        - traefik.tcp.routers.rabbitmq.rule=HostSNI(`*`)
+        - traefik.tcp.routers.rabbitmq.entrypoints=broker
 
   jaeger:
     image: jaegertracing/all-in-one:1.13
@@ -138,25 +151,24 @@ services:
         constraints: [node.role == worker]
 
   traefik:
-    image: traefik:v1.7
+    image: traefik:v2.2
     command: >
       traefik
-        --docker
-        --docker.watch
-        --docker.swarmMode
-        --docker.exposedByDefault=false
-        --entryPoints='Name:http Address::80 Redirect.EntryPoint:https'
-        --entryPoints='Name:https Address::443 TLS'
-        --defaultEntryPoints=http,https
+        --providers.docker
+        --providers.docker.watch
+        --providers.docker.swarmMode
+        --providers.docker.exposedByDefault=false
+        --entrypoints.http.address=:80
+        --entrypoints.management.address=:15672
+        --entrypoints.broker.address=:5672
     ports:
       - '80:80'
-      - '443:443'
+      - '5672:5672'
+      - '15672:15672'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     deploy:
       mode: global
-      placement:
-        constraints: [node.role == manager]
 
 volumes:
   mainflux-things-db-volume:


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
In order to route AMQP messages we need to use a new traefik mechanism
that enables routing generic TCP messages. For that reason, this patch
migrates the traefik reverse proxy to its new version.

https://docs.traefik.io/migration/v1-to-v2/

Does this close any currently open issues?
------------------------------------------
Nops

Any relevant logs, error output, etc?
-------------------------------------
Nops.

Any other comments?
-------------------
Nops.