### PR TITLE
chore(cli): Print token after user creation

### DIFF
--- a/src/cmds/cloud/createUser.js
+++ b/src/cmds/cloud/createUser.js
@@ -12,7 +12,9 @@ const createUser = async (args) => {
 
   try {
     await client.createUser(args.email, args.password);
+    const token = await client.createToken(args.email, args.password);
     console.log(chalk.green('user successfully created'));
+    console.log(chalk.grey(JSON.stringify(token, null, 2)));
   } catch (err) {
     if (err.code === 409) {
       console.log(chalk.red(`user ${args.email} is already created :/`));


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch adds a log to show the token after user creation. This will avoid the user to run two commands every time.

Does this close any currently open issues?
------------------------------------------
N.

Any relevant logs, error output, etc?
-------------------------------------
N.

Any other comments?
-------------------
N.

Where has this been tested?
---------------------------

**Operating System/Platform:** macOS Darwin - 18.0.0

**NPM Version:** v6.14.4

**NodeJS Version:** v12.16.2