### PR TITLE
chore(release): Bump to v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [2.1.0](https://github.com/CESARBR/knot-cloud/compare/v2.0.0...v2.1.0)
+
+### Features
+
+- Improve KNoT Cloud core stack modularity
+- Add `--no-clone` option to avoid cloning the repositories when workspace is already prepared
+- Show token when user is created
+
 # [2.0.0](https://github.com/CESARBR/knot-cloud/compare/v1.4.0...v2.0.0)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cesarbr/knot-cloud",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cesarbr/knot-cloud",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "KNoT Cloud CLI",
   "contributors": [
     "Thiago Cardoso <thiago.figuerdo@cesar.org.br>",


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch bumps the package version to v2.1.0. The main changes are described in the CHANGELOG file.

Does this close any currently open issues?
------------------------------------------
N.

Any relevant logs, error output, etc?
-------------------------------------
N.

Where has this been tested?
---------------------------
(Describe your environment setup here.)

**Operating System/Platform:** macOS Darwin 18.0.0

**NPM Version:** 6.14.4

**NodeJS Version:** 12.16.2