### PR TITLE
Update KNoT Cloud CLI and stack

### DIFF
--- a/src/cmds/cloud/createToken.js
+++ b/src/cmds/cloud/createToken.js
@@ -10,13 +10,13 @@ const createToken = async (args) => {
     protocol: args.protocol,
   });
 
-  return client.createToken(args.email, args.password);
+  return client.createToken(args.email, args.credential, args.type);
 };
 
 yargs
   .command({
-    command: 'create-token <email> <password>',
-    desc: "Create a new user's token",
+    command: 'create-token <email> <credential> <type>',
+    desc: 'Create a new user or app token',
     builder: (_yargs) => {
       _yargs
         .options({
@@ -24,6 +24,11 @@ yargs
             describe: 'Server hostname',
             demandOption: true,
             default: 'api.knot.cloud',
+          },
+          port: {
+            describe: 'Server port',
+            demandOption: true,
+            default: 443,
           },
           protocol: {
             describe: 'Server protocol',

--- a/src/cmds/cloud/createUser.js
+++ b/src/cmds/cloud/createUser.js
@@ -12,7 +12,7 @@ const createUser = async (args) => {
 
   try {
     await client.createUser(args.email, args.password);
-    const token = await client.createToken(args.email, args.password);
+    const token = await client.createToken(args.email, args.password, 'user');
     console.log(chalk.green('user successfully created'));
     console.log(chalk.grey(JSON.stringify(token, null, 2)));
   } catch (err) {

--- a/stacks/core/dev/env.d/knot-babeltower.env
+++ b/stacks/core/dev/env.d/knot-babeltower.env
@@ -1,4 +1,5 @@
 ENV=development
 RABBITMQ_URL=amqp://knot:knot@rabbitmq
 USERS_HOSTNAME=users
+AUTHN_HOSTNAME=authn
 THINGS_HOSTNAME=things

--- a/stacks/core/prod/env.d/knot-babeltower.env
+++ b/stacks/core/prod/env.d/knot-babeltower.env
@@ -1,3 +1,4 @@
 RABBITMQ_URL=amqp://knot:knot@rabbitmq
 USERS_HOSTNAME=users
+AUTHN_HOSTNAME=authn
 THINGS_HOSTNAME=things


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch updates the CLI to create user or app tokens and change stacks to configure authn service

Where has this been tested?
---------------------------
**Operating System/Platform:** Ubuntu 18.04
**NPM Version:** 6.14
**NodeJS Version:** 12.15
