### PR TITLE
Bump version to v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [3.0.0](https://github.com/CESARBR/knot-cloud/compare/v2.1.0...v3.0.0)
+
+### Features
+
+- Bump @cesarbr/knot-cloud-sdk-js to v3.0.0
+
 # [2.1.0](https://github.com/CESARBR/knot-cloud/compare/v2.0.0...v2.1.0)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1018,29 +1018,29 @@
       }
     },
     "@cesarbr/knot-cloud-sdk-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js/-/knot-cloud-sdk-js-2.1.0.tgz",
-      "integrity": "sha512-ycHHi1SYt9is9DDDl4SGXxJ4qVxg4m+vTpQ7af+nm24OHFxIYCL9mtaIr9wGhrqQ7q/Klhi3Q9CgkT5ApdxRvQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js/-/knot-cloud-sdk-js-3.0.0.tgz",
+      "integrity": "sha512-MZZqCikF/pBLRrBTJZqayUceYiX5sw1MS7CxExg0ZNO3KA3nXJT0CZ3uAr1W7acUekNJSOW4PhD2ZosZnYO0DA==",
       "requires": {
-        "@cesarbr/knot-cloud-sdk-js-amqp": "^1.0.1",
-        "@cesarbr/knot-cloud-sdk-js-authenticator": "^2.0.1",
+        "@cesarbr/knot-cloud-sdk-js-amqp": "^2.0.0",
+        "@cesarbr/knot-cloud-sdk-js-authenticator": "^2.1.0",
         "@cesarbr/knot-cloud-sdk-js-storage": "^1.0.2",
         "@rollup/plugin-json": "^4.0.2"
       }
     },
     "@cesarbr/knot-cloud-sdk-js-amqp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-amqp/-/knot-cloud-sdk-js-amqp-1.0.1.tgz",
-      "integrity": "sha512-undRzIz5IpXpLUC25jYbfbOGFdkpnnBnV0JtVLj6LXLl4BR0fFxk6pl10H1fwSRDJ0TfT5UDjqBsuJQ5o37u4Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-amqp/-/knot-cloud-sdk-js-amqp-2.0.0.tgz",
+      "integrity": "sha512-JgyqaanMwVdqMVEpwcKUf6qJ6T6cRmvdT6u+72ZVhNnsRNLqXBLfpViEv3OEgY44YjHMBfGt95upSZWriXzvbQ==",
       "requires": {
         "amqplib": "^0.5.5",
         "uniqid": "^5.2.0"
       }
     },
     "@cesarbr/knot-cloud-sdk-js-authenticator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-authenticator/-/knot-cloud-sdk-js-authenticator-2.0.1.tgz",
-      "integrity": "sha512-P/XI7MxL0b+DcR3LtpUAe6z2SBwOmC3AmFHrcQR/NIuwXFm6ytcLtGgq+4+3HSy0ql15IZSbtmMWJ8LBvW6ZMw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-authenticator/-/knot-cloud-sdk-js-authenticator-2.1.0.tgz",
+      "integrity": "sha512-zvZSqq6+gBKZXLI3LLzd3Qji6iq8JzAnxNW+2HiyFVQ9tJI5emvPLuhkNpsQZCwrJTfC1UMw3h8ixAqpc/M2ow==",
       "requires": {
         "axios": "^0.19.0"
       }
@@ -1055,17 +1055,17 @@
       }
     },
     "@rollup/plugin-json": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.0.3.tgz",
-      "integrity": "sha512-QMUT0HZNf4CX17LMdwaslzlYHUKTYGuuk34yYIgZrNdu+pMEfqMS55gck7HEeHBKXHM4cz5Dg1OVwythDdbbuQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
       "requires": {
         "@rollup/pluginutils": "^3.0.8"
       }
     },
     "@rollup/pluginutils": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.10.tgz",
-      "integrity": "sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
       "requires": {
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cesarbr/knot-cloud",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint"
   ],
   "dependencies": {
-    "@cesarbr/knot-cloud-sdk-js": "^2.1.0",
+    "@cesarbr/knot-cloud-sdk-js": "^3.0.0",
     "chalk": "^4.0.0",
     "colors": "^1.3.3",
     "fs-extra": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cesarbr/knot-cloud",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "KNoT Cloud CLI",
   "contributors": [
     "Thiago Cardoso <thiago.figuerdo@cesar.org.br>",


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch bumps the version to v3.0.0. The main change was to update the KNoT Cloud SDK version to use a compatible with the new AMQP API.