### PR TITLE
add jaeger dependency on authn

### DIFF
--- a/stacks/core/base/base.yml
+++ b/stacks/core/base/base.yml
@@ -24,6 +24,7 @@ services:
     env_file: './env.d/mainflux-authn.env'
     depends_on:
       - authn-db
+      - jaeger
     deploy:
       replicas: 1
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug in the creation of the `mainflux/authn` service. In its section `depends_on`,  the dependency `jaeger` was added.

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
No.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Operating System/Platform:** Ubuntu 20.4 LTS/Linux

**NPM Version:** 6.14.4

**NodeJS Version:** 10.19.0
