### PR TITLE
docs: Add secret creation instruction

### DIFF
--- a/stacks/core/README.md
+++ b/stacks/core/README.md
@@ -60,6 +60,14 @@ This stack will be deployed with the basic services, which are related to the th
 
 #### Production
 
+Firstly, create a new secret to the authenticaton service.
+
+  ```bash
+  openssl rand -base64 256
+  ```
+
+With the generated string, update the `MF_AUTHN_SECRET` environment variable in the `/env.d/mainflux-authn.env` file.
+
 The deployment to production can be done without switching to another directory. It can be done as follows:
 
 ```bash


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
As we need to use a custom secret key when deploying the authentication service to production, this patch adds an instruction to the README so that developers can configure it easily.

Where has this been tested?
---------------------------
(Describe your environment setup here.)

**Operating System/Platform:** macOS Darwin - 18.0.0

**NPM Version:** 6.14.4

**NodeJS Version:** v12.16.2