### PR TITLE
cli: cloud: Add update config

### DIFF
--- a/src/cmds/cloud/examples/config.json
+++ b/src/cmds/cloud/examples/config.json
@@ -1,0 +1,7 @@
+{
+    "sensorId": 0,
+    "change": true,
+    "timeSec": 10,
+    "lowerThreshold": 1000,
+    "upperThreshold": 3000
+}

--- a/src/cmds/cloud/listThings.js
+++ b/src/cmds/cloud/listThings.js
@@ -1,3 +1,4 @@
+
 /* eslint-disable no-console */
 import yargs from 'yargs';
 import chalk from 'chalk';
@@ -12,6 +13,9 @@ const printThings = (devices) => {
     console.log(`${chalk.green.bold('name')}: ${chalk.blueBright(d.name)}`);
     if (d.schema) {
       console.log(`${chalk.green.bold('schema')}: ${chalk.blueBright(JSON.stringify(d.schema, null, 2))}`);
+    }
+    if (d.config) {
+      console.log(`${chalk.green.bold('config')}: ${chalk.blueBright(JSON.stringify(d.config, null, 2))}`);
     }
     console.log('\n');
   });

--- a/src/cmds/cloud/updateConfig.js
+++ b/src/cmds/cloud/updateConfig.js
@@ -1,0 +1,88 @@
+/* eslint-disable no-console */
+import yargs from 'yargs';
+import fs from 'fs';
+import chalk from 'chalk';
+import { Client } from '@cesarbr/knot-cloud-sdk-js';
+import options from './utils/options';
+import getFileCredentials from './utils/getFileCredentials';
+
+const getFileConfig = (filePath) => {
+  const rawData = fs.readFileSync(filePath);
+  const config = JSON.parse(rawData);
+  return {
+    'sensor-id': config.sensorId,
+    change: config.change,
+    'time-sec': config.timeSec,
+    'lower-threshold': config.lowerThreshold,
+    'upper-threshold': config.upperThreshold,
+  };
+};
+
+const updateConfig = async (args) => {
+  const client = new Client({
+    hostname: args.server,
+    port: args.port,
+    protocol: args.protocol,
+    username: args.username,
+    password: args.password,
+    token: args.token,
+  });
+
+  const config = {
+    sensorId: args.sensorId,
+    change: (args.change === 'true'),
+    timeSec: args.timeSec,
+    lowerThreshold: args.lowerThreshold,
+    upperThreshold: args.upperThreshold,
+  };
+
+  await client.connect();
+  await client.updateConfig(args.thingId, [config]);
+  await client.close();
+};
+
+yargs
+  .config('credentials-file', path => getFileCredentials(path))
+  .config('config-file', path => getFileConfig(path))
+  .command({
+    command: 'update-config <thing-id> [sensorId] [change] [timeSec] [lowerThreshold] [upperThreshold]',
+    desc: 'Update a thing schema',
+    builder: (_yargs) => {
+      _yargs
+        .options(options)
+        .positional('sensor-id', {
+          describe: 'Sensor ID',
+          demandOption: false,
+          default: 0,
+        })
+        .positional('change', {
+          describe: 'enable sending sensor data when its value changes',
+          demandOption: false,
+          default: true,
+        })
+        .positional('time-sec', {
+          describe: 'time interval in seconds that indicates when data must be sent to the cloud',
+          demandOption: false,
+          default: 10,
+        })
+        .positional('lower-threshold', {
+          describe: 'send data to the cloud if it is lower than this threshold',
+          demandOption: false,
+          default: 1000,
+        })
+        .positional('upper-threshold', {
+          describe: 'send data to the cloud if it is upper than this threshold',
+          demandOption: false,
+          default: 3000,
+        });
+    },
+    handler: async (args) => {
+      try {
+        await updateConfig(args);
+        console.log(chalk.green(`thing ${args.thingId} config updated`));
+      } catch (err) {
+        console.log(chalk.red('it was not possible to update the thing\'s config :('));
+        console.log(chalk.red(err));
+      }
+    },
+  });


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch adds the `update-config` command to the CLI.

```
knot-cloud update-config <thing-id> [sensorId] [change] [timeSec]
[lowerThreshold] [upperThreshold]

Update a thing schema

Positionals:
  sensor-id        Sensor ID                                        [default: 0]
  change           enable sending sensor data when its value changes
                                                                 [default: true]
  time-sec         time interval in seconds that indicates when data must be
                   sent to the cloud                               [default: 10]
  lower-threshold  send data to the cloud if it is lower than this threshold
                                                                 [default: 1000]
  upper-threshold  send data to the cloud if it is upper than this threshold
                                                                 [default: 3000]
```
Does this close any currently open issues?
------------------------------------------
Nops.

Any relevant logs, error output, etc?
-------------------------------------
Nops.

Where has this been tested?
---------------------------
(Describe your environment setup here.)

**Operating System/Platform:** macOS Darwin - 18.0.0

**NPM Version:** 6.14.4

**NodeJS Version:** v12.16.2