### PR TITLE
Add update config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1018,37 +1018,38 @@
       }
     },
     "@cesarbr/knot-cloud-sdk-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js/-/knot-cloud-sdk-js-3.0.0.tgz",
-      "integrity": "sha512-MZZqCikF/pBLRrBTJZqayUceYiX5sw1MS7CxExg0ZNO3KA3nXJT0CZ3uAr1W7acUekNJSOW4PhD2ZosZnYO0DA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js/-/knot-cloud-sdk-js-3.2.0.tgz",
+      "integrity": "sha512-PPcAIfWXvaGX6gR1rKu9jG0dehQy2sA3T2r4KYpimWkbHeKicrmOanrhyZro2GRehdUULCSNkRhf2MCUVL0MHw==",
       "requires": {
-        "@cesarbr/knot-cloud-sdk-js-amqp": "^2.0.0",
-        "@cesarbr/knot-cloud-sdk-js-authenticator": "^2.1.0",
-        "@cesarbr/knot-cloud-sdk-js-storage": "^1.0.2",
+        "@cesarbr/knot-cloud-sdk-js-amqp": "^3.0.0",
+        "@cesarbr/knot-cloud-sdk-js-authenticator": "^2.1.1",
+        "@cesarbr/knot-cloud-sdk-js-storage": "^1.0.3",
         "@rollup/plugin-json": "^4.0.2"
       }
     },
     "@cesarbr/knot-cloud-sdk-js-amqp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-amqp/-/knot-cloud-sdk-js-amqp-2.0.0.tgz",
-      "integrity": "sha512-JgyqaanMwVdqMVEpwcKUf6qJ6T6cRmvdT6u+72ZVhNnsRNLqXBLfpViEv3OEgY44YjHMBfGt95upSZWriXzvbQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-amqp/-/knot-cloud-sdk-js-amqp-3.0.0.tgz",
+      "integrity": "sha512-HUS0f1YCcUKLr+70w7UK0J5wweX3g5OLogX6HIj76MjIq+8tcxpEY+wk9DHsZM4AlHitmgO2SqxCz6YUoXUZHQ==",
       "requires": {
+        "amqp-connection-manager": "^3.2.0",
         "amqplib": "^0.5.5",
         "uniqid": "^5.2.0"
       }
     },
     "@cesarbr/knot-cloud-sdk-js-authenticator": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-authenticator/-/knot-cloud-sdk-js-authenticator-2.1.0.tgz",
-      "integrity": "sha512-zvZSqq6+gBKZXLI3LLzd3Qji6iq8JzAnxNW+2HiyFVQ9tJI5emvPLuhkNpsQZCwrJTfC1UMw3h8ixAqpc/M2ow==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-authenticator/-/knot-cloud-sdk-js-authenticator-2.1.1.tgz",
+      "integrity": "sha512-FZ1suKKyANGYh0RqQaKNSEQCCpMiotZA+Cjts/3ieAmw4qQO9ChV/fO/gVPL+65uVmN7VMuXXyPvP2g5XEMcwg==",
       "requires": {
         "axios": "^0.19.0"
       }
     },
     "@cesarbr/knot-cloud-sdk-js-storage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-storage/-/knot-cloud-sdk-js-storage-1.0.2.tgz",
-      "integrity": "sha512-35kA7LTgSodH1VCQ7aIltmuSN5SYz0ADQEXnmXuwbmKB5rukNUejCDziGz342mdvczVlRJ8BGF8fckyiTCxWYQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-storage/-/knot-cloud-sdk-js-storage-1.0.3.tgz",
+      "integrity": "sha512-cgr5heqCxhAAdAY/Do6JfEP2qp8kunKrXWtCSXiyNeX616fZrEUJu8vuKn5R7oQgFth+CXK/PcECKvA+zps2ww==",
       "requires": {
         "axios": "^0.19.0",
         "url": "^0.11.0"
@@ -1104,6 +1105,14 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "amqp-connection-manager": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/amqp-connection-manager/-/amqp-connection-manager-3.2.1.tgz",
+      "integrity": "sha512-dDs2hg8MEtuYlXMzIqWwFx4N5Fjm8vXAQNyukDavyrYsgnQVt+rtJ+oosMP7eOXukSdquCoVqOaWr/Ih6txwTA==",
+      "requires": {
+        "promise-breaker": "^5.0.0"
       }
     },
     "amqplib": {
@@ -5431,6 +5440,11 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-breaker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/promise-breaker/-/promise-breaker-5.0.0.tgz",
+      "integrity": "sha512-mgsWQuG4kJ1dtO6e/QlNDLFtMkMzzecsC69aI5hlLEjGHFNpHrvGhFi4LiK5jg2SMQj74/diH+wZliL9LpGsyA=="
+    },
     "prompt": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
@@ -5483,9 +5497,9 @@
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "read": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint"
   ],
   "dependencies": {
-    "@cesarbr/knot-cloud-sdk-js": "^3.0.0",
+    "@cesarbr/knot-cloud-sdk-js": "^3.2.0",
     "chalk": "^4.0.0",
     "colors": "^1.3.3",
     "fs-extra": "^7.0.1",

--- a/src/cmds/cloud/examples/config.json
+++ b/src/cmds/cloud/examples/config.json
@@ -1,0 +1,13 @@
+{
+    "sensorId": 0,
+    "schema": {
+        "valueType": 3,
+        "unit": 0,
+        "typeId": 65521,
+        "name": "Sensor Example"
+    },
+    "event": {
+        "change": true,
+        "timeSec": 10
+    }
+}

--- a/src/cmds/cloud/examples/event.json
+++ b/src/cmds/cloud/examples/event.json
@@ -1,0 +1,5 @@
+{
+    "sensorId": 0,
+    "change": true,
+    "timeSec": 10
+}

--- a/src/cmds/cloud/listThings.js
+++ b/src/cmds/cloud/listThings.js
@@ -1,3 +1,4 @@
+
 /* eslint-disable no-console */
 import yargs from 'yargs';
 import chalk from 'chalk';
@@ -10,8 +11,8 @@ const printThings = (devices) => {
   devices.forEach((d) => {
     console.log(`${chalk.green.bold('id')}: ${chalk.blueBright(d.id)}`);
     console.log(`${chalk.green.bold('name')}: ${chalk.blueBright(d.name)}`);
-    if (d.schema) {
-      console.log(`${chalk.green.bold('schema')}: ${chalk.blueBright(JSON.stringify(d.schema, null, 2))}`);
+    if (d.config) {
+      console.log(`${chalk.green.bold('config')}: ${chalk.blueBright(JSON.stringify(d.config, null, 2))}`);
     }
     console.log('\n');
   });

--- a/src/cmds/cloud/updateConfig.js
+++ b/src/cmds/cloud/updateConfig.js
@@ -1,0 +1,56 @@
+/* eslint-disable no-console */
+import yargs from 'yargs';
+import fs from 'fs';
+import chalk from 'chalk';
+import { Client } from '@cesarbr/knot-cloud-sdk-js';
+import options from './utils/options';
+import getFileCredentials from './utils/getFileCredentials';
+
+const getFileConfig = (filePath) => {
+  const rawData = fs.readFileSync(filePath);
+  return JSON.parse(rawData);
+};
+
+const updateConfig = async (args) => {
+  const client = new Client({
+    hostname: args.server,
+    port: args.port,
+    protocol: args.protocol,
+    username: args.username,
+    password: args.password,
+    token: args.token,
+  });
+
+  const config = getFileConfig(args.filePath);
+
+  await client.connect();
+  const response = await client.updateConfig(args.thingId, [config]);
+  console.log(response);
+  await client.close();
+};
+
+yargs
+  .config('credentials-file', path => getFileCredentials(path))
+  // .config('config-file', path => getFileConfig(path))
+  .command({
+    command: 'update-config <thing-id> <file-path>',
+    desc: 'Update a thing configuration from a file',
+    builder: (_yargs) => {
+      _yargs
+        .positional('file-path', {
+          describe: 'Config file path',
+          demandOption: true,
+          default: 0,
+        })
+        .options(options);
+    },
+    handler: async (args) => {
+      try {
+        await updateConfig(args);
+        console.log(chalk.green(`thing ${args.thingId} config updated`));
+      } catch (err) {
+        console.log(chalk.red('it was not possible to update the thing\'s config :('));
+        console.log(chalk.red(err));
+      }
+    },
+  });

--- a/src/cmds/cloud/updateConfigEvent.js
+++ b/src/cmds/cloud/updateConfigEvent.js
@@ -1,0 +1,91 @@
+/* eslint-disable no-console */
+import yargs from 'yargs';
+import fs from 'fs';
+import chalk from 'chalk';
+import { Client } from '@cesarbr/knot-cloud-sdk-js';
+import options from './utils/options';
+import getFileCredentials from './utils/getFileCredentials';
+
+const getFileConfig = (filePath) => {
+  const rawData = fs.readFileSync(filePath);
+  const config = JSON.parse(rawData);
+  return {
+    'sensor-id': config.sensorId,
+    change: config.change,
+    'time-sec': config.timeSec,
+    'lower-threshold': config.lowerThreshold,
+    'upper-threshold': config.upperThreshold,
+  };
+};
+
+const updateConfigEvent = async (args) => {
+  const client = new Client({
+    hostname: args.server,
+    port: args.port,
+    protocol: args.protocol,
+    username: args.username,
+    password: args.password,
+    token: args.token,
+  });
+
+  const config = {
+    sensorId: args.sensorId,
+    event: {
+      change: (args.change === 'true'),
+      timeSec: args.timeSec,
+      lowerThreshold: args.lowerThreshold,
+      upperThreshold: args.upperThreshold,
+    },
+  };
+
+  await client.connect();
+  const response = await client.updateConfig(args.thingId, [config]);
+  console.log(response);
+  await client.close();
+};
+
+yargs
+  .config('credentials-file', path => getFileCredentials(path))
+  .config('event-file', path => getFileConfig(path))
+  .command({
+    command: 'update-config-event <thing-id> <sensor-id> [change] [timeSec] [lowerThreshold] [upperThreshold]',
+    desc: 'Update a thing schema',
+    builder: (_yargs) => {
+      _yargs
+        .options(options)
+        .positional('sensor-id', {
+          describe: 'Sensor ID',
+          demandOption: true,
+          default: 0,
+        })
+        .positional('change', {
+          describe: 'enable sending sensor data when its value changes',
+          demandOption: false,
+          default: true,
+        })
+        .positional('time-sec', {
+          describe: 'time interval in seconds that indicates when data must be sent to the cloud',
+          demandOption: false,
+          default: 10,
+        })
+        .positional('lower-threshold', {
+          describe: 'send data to the cloud if it is lower than this threshold',
+          demandOption: false,
+          default: 1000,
+        })
+        .positional('upper-threshold', {
+          describe: 'send data to the cloud if it is upper than this threshold',
+          demandOption: false,
+          default: 3000,
+        });
+    },
+    handler: async (args) => {
+      try {
+        await updateConfigEvent(args);
+        console.log(chalk.green(`thing ${args.thingId} config updated`));
+      } catch (err) {
+        console.log(chalk.red('it was not possible to update the thing\'s config :('));
+        console.log(chalk.red(err));
+      }
+    },
+  });

--- a/src/cmds/cloud/updateConfigSchema.js
+++ b/src/cmds/cloud/updateConfigSchema.js
@@ -18,7 +18,7 @@ const getFileSchema = (filePath) => {
   };
 };
 
-const updateSchema = async (args) => {
+const updateConfigSchema = async (args) => {
   const client = new Client({
     hostname: args.server,
     port: args.port,
@@ -28,16 +28,19 @@ const updateSchema = async (args) => {
     token: args.token,
   });
 
-  const schema = {
+  const config = {
     sensorId: args.sensorId,
-    valueType: args.valueType,
-    unit: args.unit,
-    typeId: args.typeId,
-    name: args.name,
+    schema: {
+      valueType: args.valueType,
+      unit: args.unit,
+      typeId: args.typeId,
+      name: args.name,
+    },
   };
 
   await client.connect();
-  await client.updateSchema(args.thingId, [schema]);
+  const response = await client.updateConfig(args.thingId, [config]);
+  console.log(response);
   await client.close();
 };
 
@@ -45,14 +48,14 @@ yargs
   .config('credentials-file', path => getFileCredentials(path))
   .config('schema-file', path => getFileSchema(path))
   .command({
-    command: 'update-schema <thing-id> [sensor-id] [value-type] [unit] [type-id] [name]',
+    command: 'update-config-schema <thing-id> <sensor-id> [value-type] [unit] [type-id] [name]',
     desc: 'Update a thing schema',
     builder: (_yargs) => {
       _yargs
         .options(options)
         .positional('sensor-id', {
           describe: 'Sensor ID',
-          demandOption: false,
+          demandOption: true,
           default: 0,
         })
         .positional('value-type', {
@@ -78,7 +81,7 @@ yargs
     },
     handler: async (args) => {
       try {
-        await updateSchema(args);
+        await updateConfigSchema(args);
         console.log(chalk.green(`thing ${args.thingId} schema updated`));
       } catch (err) {
         console.log(chalk.red('it was not possible to update the thing\'s schema :('));


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch adds the new update config operation. It basically represents both schema and event flags now, so the previous update schema was refactored.

Where has this been tested?
---------------------------
**Operating System/Platform:** macOS - Darwin 18.0.0

**NPM Version:** 6.14.4

**NodeJS Version:** v12.16.2