### PR TITLE
Add logs limit to docker containers

### DIFF
--- a/src/cmds/stack/setup.js
+++ b/src/cmds/stack/setup.js
@@ -5,9 +5,9 @@ import path from 'path';
 import yargs from 'yargs';
 
 const KNOT_CLOUD_REPOSITORIES = [
-  'CESARBR/knot-babeltower',
-  'CESARBR/knot-cloud-storage',
-  'CESARBR/knot-fog-connector',
+  'CESARBR/knot-babeltower:KNoTU-v3.1.0-rc05',
+  'CESARBR/knot-cloud-storage:KNoTU-v3.1.0-rc05',
+  'CESARBR/knot-fog-connector:KNOT-v03.00-rc04',
 ];
 
 const KNOT_ERR_FILE = 'knot.err';

--- a/stacks/cloud/addons/connector.dev.yml
+++ b/stacks/cloud/addons/connector.dev.yml
@@ -6,7 +6,14 @@ services:
     env_file: './env.d/knot-connector.env'
     volumes:
       - ../knot-fog-connector:/usr/src/app
+      - "/etc/timezone:/etc/timezone:ro"
+      - "/etc/localtime:/etc/localtime:ro"
     depends_on:
       - rabbitmq
     deploy:
       replicas: 1
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+        max-file: 3

--- a/stacks/cloud/addons/connector.yml
+++ b/stacks/cloud/addons/connector.yml
@@ -2,9 +2,17 @@ version: '3.7'
 
 services:
   connector:
-    image: cesarbr/knot-fog-connector
+    image: cesarbr/knot-fog-connector:KNOT-v03.00-rc04
     env_file: './env.d/knot-connector.env'
+    volumes:
+      - "/etc/timezone:/etc/timezone:ro"
+      - "/etc/localtime:/etc/localtime:ro"
     depends_on:
       - rabbitmq
     deploy:
       replicas: 1
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+        max-file: 3

--- a/stacks/cloud/base/base.yml
+++ b/stacks/cloud/base/base.yml
@@ -27,10 +27,18 @@ services:
       - jaeger
     deploy:
       replicas: 1
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+        max-file: 3
 
   # KNoT Fog Core
   babeltower:
-    image: cesarbr/knot-babeltower
+    image: cesarbr/knot-babeltower:KNoTU-v3.1.0-rc05
+    volumes:
+      - "/etc/timezone:/etc/timezone:ro"
+      - "/etc/localtime:/etc/localtime:ro"
     env_file: './env.d/knot-babeltower.env'
     depends_on:
       - rabbitmq
@@ -38,14 +46,27 @@ services:
       - things
     deploy:
       replicas: 1
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+        max-file: 3
 
   storage:
-    image: cesarbr/knot-cloud-storage
+    image: cesarbr/knot-cloud-storage:KNoTU-v3.1.0-rc05
+    volumes:
+     - "/etc/timezone:/etc/timezone:ro"
+     - "/etc/localtime:/etc/localtime:ro"
     env_file: './env.d/knot-cloud-storage.env'
     depends_on:
       - mongo
     deploy:
       replicas: 1
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+        max-file: 3
 
   # External dependencies: database, tracing, message broker, load balancer.
   things-redis:
@@ -89,7 +110,7 @@ services:
       replicas: 1
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3.9.22
     env_file: './env.d/rabbitmq.env'
     volumes:
       - rabbitmq-data:/var/lib/rabbitmq
@@ -106,6 +127,8 @@ services:
     image: mongo
     volumes:
       - mongo-data:/data/db
+      - "/etc/timezone:/etc/timezone:ro"
+      - "/etc/localtime:/etc/localtime:ro"
     deploy:
       replicas: 1
       resources:

--- a/stacks/cloud/dev/dev.yml
+++ b/stacks/cloud/dev/dev.yml
@@ -6,11 +6,21 @@ services:
     image: cesarbr/knot-babeltower:dev
     volumes:
       - ../knot-babeltower:/usr/src/app
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+        max-file: 3
 
   storage:
     image: cesarbr/knot-cloud-storage:dev
     volumes:
       - ../knot-cloud-storage:/usr/src/app
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+        max-file: 3
 
   rabbitmq:
-    image: rabbitmq:management
+    image: rabbitmq:3.9.22


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch introduces the following changes:

- Limit the amount of knot-cloud logs;
- Fix knot-cloud timestamp;

Where has this been tested?
---------------------------
**Operating System/Platform:** Ubuntu 20.04.04 LTS

**NPM Version:** 6.13.4

**NodeJS Version:** 10.19.0
